### PR TITLE
Update movement_trainer_entrance.lua

### DIFF
--- a/data-otservbr-global/scripts/custom/movement_trainer_entrance.lua
+++ b/data-otservbr-global/scripts/custom/movement_trainer_entrance.lua
@@ -12,9 +12,9 @@ local config = {
 }
 
 local function isBusyable(position)
-	local player = Tile(position):getTopCreature()
-	if player then
-		if player:isPlayer() then
+	local creature = Tile(position):getTopCreature()
+	if creature then
+		if creature:isPlayer() or creature:getMaster() then
 			return false
 		end
 	end


### PR DESCRIPTION
# Description

Currently players are able to go into a training room that's already busy if there is a summon standing on the tile, this will fix that issue.

## Behaviour
### **Actual**

Go into trainers with a summon/familiar alive, if another player tries to go into trainers he will be placed in the same training room.

### **Expected**

Training room should be limited to one person.

## Type of change

Please delete options that are not relevant.

  - [X ] Bug fix (non-breaking change which fixes an issue)
